### PR TITLE
Update basicinspector.lua

### DIFF
--- a/classes/basicinspector.lua
+++ b/classes/basicinspector.lua
@@ -405,7 +405,7 @@ tbug._BasicInspectorPanel_onRowMouseEnter = {
                 if height > tbug.maxInspectorTexturePreviewHeight then
                     height = tbug.maxInspectorTexturePreviewHeight
                 end
-                local textureText = zo_iconTextFormatNoSpace(value, width, height, "", nil)
+                local textureText = zo_iconTextFormatNoSpace(tostring(value, width, height, "", nil))
                 if textureText and textureText ~= "" then
                     ZO_Tooltips_ShowTextTooltip(row, RIGHT, textureText)
                 end


### PR DESCRIPTION
tostring the vars passed to zo_iconTextFormatNoSpace to prevent the error 
```
bad argument #4 to 'string.format' (string expected, got boolean)
stack traceback:
[C]: in function 'string.format'
EsoUI/Libraries/Globals/globalapi.lua:200: in function 'zo_iconFormat'
|caaaaaa<Locals> path = T, width = 48, height = 48 </Locals>|r
EsoUI/Libraries/Globals/globalapi.lua:220: in function 'zo_iconTextFormatNoSpace'
|caaaaaa<Locals> path = T, width = 48, height = 48, text = "", iconFormatter = EsoUI/Libraries/Globals/globalapi.lua:199 </Locals>|r
user:/AddOns/merTorchbug/classes/basicinspector.lua:408: in function 'BasicInspectorPanel:onRowMouseEnter'
|caaaaaa<Locals> self = [table:1]{_pendingUpdate = 0, _pkey = 2, filterFunc = F, _lockedForUpdates = F, dropdownFilterFunc = F}, row = ud, data = [table:2]{value = T, key = "textureFileName"}, key = "textureFileName", propName = "textureFileName", value = T, typeId = 1, width = 48, height = 48 </Locals>|r
user:/AddOns/merTorchbug/classes/basicinspector.lua:92: in function 'rowMouseEnter'
|caaaaaa<Locals> row = ud, data = [table:2] </Locals>|r
```