### PR TITLE
Implemented the TODO comment

### DIFF
--- a/merTorchbug/modules/glookup.lua
+++ b/merTorchbug/modules/glookup.lua
@@ -10,6 +10,7 @@ local strfind = string.find
 local strmatch = string.match
 local strsub = string.sub
 local strup = string.upper
+local strlower = string.lower
 
 local strsplit = tbug.strSplit
 local zo_strsplit = zo_strsplit
@@ -355,9 +356,10 @@ local function doRefresh()
     tbug.foreachValue(g_enums, ZO_ClearTable)
     tbug.foreachValue(g_tmpGroups, ZO_ClearTable)
 
+	local libComparisonVar = "lib"
 	local function isLibraryGlobal(name)
-		-- Check if the name starts with "Lib" or "LIB"
-		return type(name) == "string" and (strsub(name, 1, 3) == "Lib" or strsub(name, 1, 3) == "LIB")
+		-- Check if the name starts with "Lib", "LIB" or "lib"
+		return type(name) == "string" and (strlower(strsub(name, 1, 3)) == libComparisonVar)
 	end
 
 	local function processLibraryGlobal(name, lib)


### PR DESCRIPTION
Libraries without LibStub: Check for global variables starting with "Lib" or "LIB"

This allows us to possibly use the use as script right click functionality. It still just uses the base key instead of the new "lib" prefixed function.

This is with this code change,

![image](https://github.com/user-attachments/assets/6ce47204-0f5a-4cbf-b09e-fba221da3497)

This is what it shows currently.

![image](https://github.com/user-attachments/assets/fd674595-ba92-4e85-ba89-10d97dd8bf6b)

